### PR TITLE
Update csScanner.cpp

### DIFF
--- a/ClawSearch/csScanner.cpp
+++ b/ClawSearch/csScanner.cpp
@@ -120,6 +120,7 @@ void csScanner::PerformScan(bool firstScan)
 
 	if (m_currentScanMap.page != nullptr) {
 		BridgeFree(m_currentScanMap.page);
+		m_currentScanMap.page = nullptr;
 	}
 
 	// If this is the very first scan
@@ -203,6 +204,7 @@ void csScanner::PerformScan(bool firstScan)
 	}
 
 	free(find);
+	find = nullptr;
 	free(m_currentCompare);
 	m_currentCompare = nullptr;
 }

--- a/ClawSearch/csScanner.cpp
+++ b/ClawSearch/csScanner.cpp
@@ -204,7 +204,6 @@ void csScanner::PerformScan(bool firstScan)
 	}
 
 	free(find);
-	find = nullptr;
 	free(m_currentCompare);
 	m_currentCompare = nullptr;
 }


### PR DESCRIPTION
BridgeFree() does not set pointer to null.  Double free was causing a crash on the second non 'first scan' because conditional was dependent on it being set to nullptr.  Added nullptr assignment to find after free().